### PR TITLE
Add configurable decompression working directory

### DIFF
--- a/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/internal/IOUtils.java
+++ b/connect-file-pulse-api/src/main/java/io/streamthoughts/kafka/connect/filepulse/internal/IOUtils.java
@@ -65,9 +65,28 @@ public class IOUtils {
         return (dotIndex == -1) ? filename : filename.substring(0, dotIndex);
     }
 
+    private static String workingDirectory;
+
+    public static void setWorkingDirectory(final String dir) {
+        workingDirectory = dir;
+    }
+
+    public static String getWorkingDirectory() {
+        return workingDirectory;
+    }
+
     public static File createDirectoryFromFile(final File file) throws IOException {
+        return createDirectoryFromFile(file, workingDirectory);
+    }
+
+    public static File createDirectoryFromFile(final File file, final String workDir) throws IOException {
         Objects.requireNonNull(file, "file cannot be null");
-        final Path unzipPath = Paths.get(file.getParentFile().getCanonicalPath(), getNameWithoutExtension(file));
+        final Path unzipPath;
+        if (workDir != null && !workDir.isEmpty()) {
+            unzipPath = Paths.get(workDir, getNameWithoutExtension(file));
+        } else {
+            unzipPath = Paths.get(file.getParentFile().getCanonicalPath(), getNameWithoutExtension(file));
+        }
         if (!Files.exists(unzipPath)) {
             Files.createDirectories(unzipPath);
         }

--- a/connect-file-pulse-filesystems/filepulse-local-fs/pom.xml
+++ b/connect-file-pulse-filesystems/filepulse-local-fs/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>commons-compress</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
         </dependency>

--- a/connect-file-pulse-filesystems/filepulse-local-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/LocalFSDirectoryListing.java
+++ b/connect-file-pulse-filesystems/filepulse-local-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/LocalFSDirectoryListing.java
@@ -9,6 +9,7 @@ package io.streamthoughts.kafka.connect.filepulse.fs;
 import io.streamthoughts.kafka.connect.filepulse.errors.ConnectFilePulseException;
 import io.streamthoughts.kafka.connect.filepulse.fs.codec.CodecHandler;
 import io.streamthoughts.kafka.connect.filepulse.fs.codec.CodecManager;
+import io.streamthoughts.kafka.connect.filepulse.internal.IOUtils;
 import io.streamthoughts.kafka.connect.filepulse.source.FileObjectMeta;
 import io.streamthoughts.kafka.connect.filepulse.source.LocalFileObjectMeta;
 import java.io.File;
@@ -24,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,6 +68,7 @@ public class LocalFSDirectoryListing implements FileSystemListing<LocalFileStora
     @Override
     public void configure(final Map<String, ?> configs) {
         config = new LocalFSDirectoryListingConfig(configs);
+        IOUtils.setWorkingDirectory(config.decompressWorkingDirectory());
     }
 
     /**
@@ -118,6 +121,7 @@ public class LocalFSDirectoryListing implements FileSystemListing<LocalFileStora
         if (config.isRecursiveScanEnable() && !directories.isEmpty()) {
             listingLocalFiles.addAll(scanRecursiveDirectories(directories, decompressedDirs));
         }
+        cleanupDecompressedDirectories(decompressedDirs);
         return listingLocalFiles;
     }
 
@@ -209,6 +213,19 @@ public class LocalFSDirectoryListing implements FileSystemListing<LocalFileStora
                 .filter(f -> !decompressedDirs.contains(f))
                 .flatMap(f -> listEligibleFiles(f).stream())
                 .collect(Collectors.toList());
+    }
+
+    private void cleanupDecompressedDirectories(List<Path> decompressedDirs) {
+        String workDir = config.decompressWorkingDirectory();
+        if (workDir != null && !workDir.isEmpty()) {
+            for (Path dir : decompressedDirs) {
+                try {
+                    FileUtils.deleteDirectory(dir.toFile());
+                } catch (IOException e) {
+                    LOG.warn("Error while deleting working directory '{}': {}", dir, e.getMessage());
+                }
+            }
+        }
     }
 
     /**

--- a/connect-file-pulse-filesystems/filepulse-local-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/LocalFSDirectoryListingConfig.java
+++ b/connect-file-pulse-filesystems/filepulse-local-fs/src/main/java/io/streamthoughts/kafka/connect/filepulse/fs/LocalFSDirectoryListingConfig.java
@@ -23,6 +23,11 @@ public class LocalFSDirectoryListingConfig extends AbstractConfig {
     private static final String FS_DELETE_COMPRESS_FILES_ENABLE_DOC = "Flag indicating whether compressed file  " +
             "should be deleted after extraction (default false)";
 
+    public static final String FS_DECOMPRESS_WORKING_DIR_CONFIG = "fs.decompress.working.dir";
+    private static final String FS_DECOMPRESS_WORKING_DIR_DOC =
+            "Directory where compressed files are decompressed before processing. " +
+            "If not set, files are decompressed next to the source file.";
+
     public static ConfigDef getConf() {
         return new ConfigDef()
                 .define(
@@ -42,7 +47,13 @@ public class LocalFSDirectoryListingConfig extends AbstractConfig {
                         ConfigDef.Type.BOOLEAN,
                         false,
                         ConfigDef.Importance.MEDIUM,
-                        FS_DELETE_COMPRESS_FILES_ENABLE_DOC);
+                        FS_DELETE_COMPRESS_FILES_ENABLE_DOC)
+                .define(
+                        FS_DECOMPRESS_WORKING_DIR_CONFIG,
+                        ConfigDef.Type.STRING,
+                        null,
+                        ConfigDef.Importance.MEDIUM,
+                        FS_DECOMPRESS_WORKING_DIR_DOC);
     }
 
     /**
@@ -63,5 +74,9 @@ public class LocalFSDirectoryListingConfig extends AbstractConfig {
 
     public boolean isDeleteCompressFileEnable() {
         return getBoolean(FS_DELETE_COMPRESS_FILES_ENABLED_CONFIG);
+    }
+
+    public String decompressWorkingDirectory() {
+        return getString(FS_DECOMPRESS_WORKING_DIR_CONFIG);
     }
 }


### PR DESCRIPTION
## Summary
- enable configurable working directory for decompressing archives
- clean up temporary directories after listing
- wire new configuration into LocalFSDirectoryListing
- depend on commons-io for directory cleanup

## Testing
- `./mvnw -DskipTests -pl connect-file-pulse-filesystems/filepulse-local-fs -am package`

------
https://chatgpt.com/codex/tasks/task_e_684b9fd0249c832fbb035f00d06e9cf2